### PR TITLE
manage running experiments

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,6 +36,7 @@ repos:
     hooks:
       - id: mypy
         exclude: 'docs/source/conf\.py'
+        args: ["--install-types","--non-interactive"]
   - repo: https://github.com/codespell-project/codespell
     rev: "v2.2.2"
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,7 +36,6 @@ repos:
     hooks:
       - id: mypy
         exclude: 'docs/source/conf\.py'
-        args: ["--install-types","--non-interactive"]
   - repo: https://github.com/codespell-project/codespell
     rev: "v2.2.2"
     hooks:
@@ -77,4 +76,4 @@ repos:
 
 ci:
   autoupdate_schedule: monthly
-  skip: ['shellcheck']
+  skip: ['shellcheck', 'mypy']

--- a/scripts/pbt.py
+++ b/scripts/pbt.py
@@ -10,7 +10,6 @@ from typing import Any
 
 import ray
 from gnn_tracking.utils.dictionaries import subdict_with_prefix_stripped
-from gnn_tracking.utils.log import logger
 from ray import air
 from ray.air.callbacks.wandb import WandbLoggerCallback
 from ray.tune import SyncConfig
@@ -22,6 +21,7 @@ from gnn_tracking_hpo.cli import add_cpu_option, add_enqueue_option, add_test_op
 from gnn_tracking_hpo.config import della, get_metadata, get_points_to_evaluate
 from gnn_tracking_hpo.orchestrate import maybe_run_distributed, maybe_run_wandb_offline
 from gnn_tracking_hpo.trainable import TCNTrainable
+from gnn_tracking_hpo.util.log import logger
 
 server = della
 

--- a/src/gnn_tracking_hpo/config.py
+++ b/src/gnn_tracking_hpo/config.py
@@ -8,8 +8,9 @@ from pathlib import Path
 from typing import Any
 
 import gnn_tracking
-from gnn_tracking.utils.log import logger
 from gnn_tracking.utils.versioning import get_commit_hash
+
+from gnn_tracking_hpo.util.log import logger
 
 
 def auto_suggest_if_not_fixed(

--- a/src/gnn_tracking_hpo/jobcontrol.py
+++ b/src/gnn_tracking_hpo/jobcontrol.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+import os
+import subprocess
+import time
+from enum import Enum, auto
+from pathlib import Path
+
+import yaml
+
+from gnn_tracking_hpo.util.log import logger
+
+
+class JobControlAction(Enum):
+    KILL_NODE = auto()
+    WAIT = auto()
+
+
+def get_slurm_job_id() -> str:
+    return os.environ["SLURM_JOB_ID"]
+
+
+def kill_slurm_job(
+    job_id: str,
+):
+    logger.info("Killing slurm job %s", job_id)
+    subprocess.run(f"scancel {job_id}")
+
+
+class JobControl:
+    def __init__(self):
+        self.job_control_path = Path.home() / "ray_job_control.yaml"
+        self.config = []
+
+    def refresh(self):
+        if not self.job_control_path.exists():
+            logger.warning("Job control file %s does not exist", self.job_control_path)
+            return
+        logger.debug("Refreshing job control config from %s", self.job_control_path)
+        with open(self.job_control_path) as f:
+            try:
+                self.config = yaml.safe_load(f)
+            except yaml.YAMLError as e:
+                logger.error("Could not load job control config: %s", e)
+                return
+
+    def _get_actions(self, ip: str, dispatcher_id: str) -> list[JobControlAction]:
+        actions = []
+        for c in self.config:
+            if c.get("ip") is not None and str(c.get("ip")) != str(ip):
+                continue
+            if c.get("dispatcher_id") is not None and str(
+                c.get("dispatcher_id")
+            ) != str(dispatcher_id):
+                continue
+            actions.append(JobControlAction[c["action"].upper()])
+        if actions:
+            logger.debug("Got actions %s", actions)
+        return actions
+
+    @staticmethod
+    def _handle_action(action: JobControlAction) -> bool:
+        if action == JobControlAction.WAIT:
+            logger.info("Sleeping for 30s")
+            time.sleep(30)
+            return False
+        if action == JobControlAction.KILL_NODE:
+            job_id = get_slurm_job_id()
+            kill_slurm_job(job_id)
+            return False
+        raise ValueError(f"Unknown action {action}")
+
+    def __call__(self, ip: str, dispatcher_id: str) -> None:
+        repeat_requested = True
+        while repeat_requested:
+            self.refresh()
+            repeat_requested = False
+            try:
+                actions = self._get_actions(ip, dispatcher_id)
+            except KeyError as e:
+                logger.error("Could not get actions, please check your config: %s", e)
+                return
+            for action in actions:
+                repeat_requested |= self._handle_action(action)

--- a/src/gnn_tracking_hpo/jobcontrol.py
+++ b/src/gnn_tracking_hpo/jobcontrol.py
@@ -139,15 +139,18 @@ class JobControl:
         return actions
 
     def _handle_action(self, action: JobControlAction) -> bool:
+        """Handles action. Returns True if we should refresh the config and check
+        if everything has been resolved afterwards.
+        """
         if action == JobControlAction.WAIT:
             self.logger.info("Sleeping for 30s")
             time.sleep(30)
-            return False
+            return True
         if action == JobControlAction.KILL_NODE:
             job_id = get_slurm_job_id()
             self.logger.warning("Killing slurm job %s", job_id)
             kill_slurm_job(job_id)
-            return False
+            return True
         raise ValueError(f"Unknown action {action}")
 
     def __call__(self, *, dispatcher_id: str) -> None:

--- a/src/gnn_tracking_hpo/load.py
+++ b/src/gnn_tracking_hpo/load.py
@@ -9,10 +9,10 @@ from pathlib import Path
 from gnn_tracking.graph_construction.graph_builder import load_graphs
 from gnn_tracking.utils.loading import get_loaders as _get_loaders
 from gnn_tracking.utils.loading import train_test_val_split
-from gnn_tracking.utils.log import logger
 from torch_geometric.loader import DataLoader
 
 from gnn_tracking_hpo.config import server
+from gnn_tracking_hpo.util.log import logger
 
 
 def get_graphs(

--- a/src/gnn_tracking_hpo/orchestrate.py
+++ b/src/gnn_tracking_hpo/orchestrate.py
@@ -5,8 +5,9 @@ from http import client as httplib
 from pathlib import Path
 
 import ray
-from gnn_tracking.utils.log import logger
 from ray.util.joblib import register_ray
+
+from gnn_tracking_hpo.util.log import logger
 
 
 def have_internet() -> bool:

--- a/src/gnn_tracking_hpo/orchestrate.py
+++ b/src/gnn_tracking_hpo/orchestrate.py
@@ -1,20 +1,12 @@
 from __future__ import annotations
 
 import os
-import subprocess
 from http import client as httplib
 from pathlib import Path
 
 import ray
 from gnn_tracking.utils.log import logger
 from ray.util.joblib import register_ray
-
-
-def get_my_ip() -> str:
-    result = subprocess.run(
-        ["hostname", "--ip-address"], capture_output=True, text=True
-    )
-    return result.stdout.strip()
 
 
 def have_internet() -> bool:

--- a/src/gnn_tracking_hpo/orchestrate.py
+++ b/src/gnn_tracking_hpo/orchestrate.py
@@ -1,12 +1,20 @@
 from __future__ import annotations
 
 import os
+import subprocess
 from http import client as httplib
 from pathlib import Path
 
 import ray
 from gnn_tracking.utils.log import logger
 from ray.util.joblib import register_ray
+
+
+def get_my_ip() -> str:
+    result = subprocess.run(
+        ["hostname", "--ip-address"], capture_output=True, text=True
+    )
+    return result.stdout.strip()
 
 
 def have_internet() -> bool:

--- a/src/gnn_tracking_hpo/trainable.py
+++ b/src/gnn_tracking_hpo/trainable.py
@@ -233,6 +233,11 @@ class TCNTrainable(tune.Trainable):
             logger.info("I'm running on a node with job ID=%s", sji)
         else:
             logger.info("I appear to be running locally.")
+        if self.dispatcher_id == 0:
+            logger.warning(
+                "Dispatcher ID was not set. This should be set by the dispatcher "
+                "as a class attribute to the trainable."
+            )
         logger.info("The ID of my dispatcher is %d", self.dispatcher_id)
         JobControl()(dispatcher_id=str(self.dispatcher_id))
         logger.debug("Got config\n%s", pprint.pformat(config))

--- a/src/gnn_tracking_hpo/trainable.py
+++ b/src/gnn_tracking_hpo/trainable.py
@@ -23,8 +23,8 @@ from ray import tune
 from torch import nn
 from torch.optim import SGD, Adam, lr_scheduler
 
-from gnn_tracking_hpo.jobcontrol import JobControl, get_slurm_job_id
 from gnn_tracking_hpo.load import get_graphs, get_loaders
+from gnn_tracking_hpo.slurmcontrol import SlurmControl, get_slurm_job_id
 from gnn_tracking_hpo.util.log import logger
 
 
@@ -239,7 +239,7 @@ class TCNTrainable(tune.Trainable):
                 "as a class attribute to the trainable."
             )
         logger.info("The ID of my dispatcher is %d", self.dispatcher_id)
-        JobControl()(dispatcher_id=str(self.dispatcher_id))
+        SlurmControl()(dispatcher_id=str(self.dispatcher_id))
         logger.debug("Got config\n%s", pprint.pformat(config))
         self.tc = config
         fix_seeds()

--- a/src/gnn_tracking_hpo/trainable.py
+++ b/src/gnn_tracking_hpo/trainable.py
@@ -18,7 +18,6 @@ from gnn_tracking.postprocessing.clusterscanner import ClusterScanResult
 from gnn_tracking.postprocessing.dbscanscanner import DBSCANHyperParamScanner
 from gnn_tracking.training.tcn_trainer import TCNTrainer, TrainingTruthCutConfig
 from gnn_tracking.utils.dictionaries import subdict_with_prefix_stripped
-from gnn_tracking.utils.log import logger
 from gnn_tracking.utils.seeds import fix_seeds
 from ray import tune
 from torch import nn
@@ -26,6 +25,7 @@ from torch.optim import SGD, Adam, lr_scheduler
 
 from gnn_tracking_hpo.jobcontrol import JobControl, get_slurm_job_id
 from gnn_tracking_hpo.load import get_graphs, get_loaders
+from gnn_tracking_hpo.util.log import logger
 
 
 def fixed_dbscan_scan(

--- a/src/gnn_tracking_hpo/tune.py
+++ b/src/gnn_tracking_hpo/tune.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import random
 from argparse import ArgumentParser
 from functools import cached_property, partial
 from pathlib import Path
@@ -180,6 +181,8 @@ class Dispatcher:
             self.additional_stoppers = []
         else:
             self.additional_stoppers = additional_stoppers
+        self.id = random.randint(1, int(1e4))
+        logger.info("Dispatcher ID: %s", self.id)
 
     def __call__(
         self,
@@ -194,6 +197,8 @@ class Dispatcher:
         Returns:
 
         """
+        trainable._dispatcher_id = self.id
+
         if self.no_tune:
             assert self.test
             simple_run_without_tune(trainable, suggest_config)

--- a/src/gnn_tracking_hpo/tune.py
+++ b/src/gnn_tracking_hpo/tune.py
@@ -197,7 +197,7 @@ class Dispatcher:
         Returns:
 
         """
-        trainable._dispatcher_id = self.id
+        trainable.dispatcher_id = self.id
 
         if self.no_tune:
             assert self.test

--- a/src/gnn_tracking_hpo/util/log.py
+++ b/src/gnn_tracking_hpo/util/log.py
@@ -8,9 +8,9 @@ import colorlog
 LOG_DEFAULT_LEVEL = logging.DEBUG
 
 
-def get_logger():
+def get_logger(name="gnn_tracking_hpo"):
     """Sets up global logger."""
-    _log = colorlog.getLogger("gnn_tracking_hpo")
+    _log = colorlog.getLogger(name)
 
     if _log.handlers:
         # the logger already has handlers attached to it, even though

--- a/src/gnn_tracking_hpo/util/log.py
+++ b/src/gnn_tracking_hpo/util/log.py
@@ -8,7 +8,7 @@ import colorlog
 LOG_DEFAULT_LEVEL = logging.DEBUG
 
 
-def get_logger(name="gnn_tracking_hpo"):
+def get_logger(name="gnnt_hpo"):
     """Sets up global logger."""
     _log = colorlog.getLogger(name)
 
@@ -29,7 +29,9 @@ def get_logger(name="gnn_tracking_hpo"):
         "CRITICAL": "red",
     }
     formatter = colorlog.ColoredFormatter(
-        "%(log_color)s%(levelname)s: %(message)s", log_colors=log_colors
+        "%(log_color)s[%(asctime)s %(name)s] %(levelname)s: %(message)s",
+        log_colors=log_colors,
+        datefmt="%H:%M:%S",
     )
     sh.setFormatter(formatter)
     # Controlled by overall logger level


### PR DESCRIPTION
- Quick and dirty first version of soft stopping
- More elaborate jobcontrol scheme
- Don't need to get IP, can get job id from env
- Implement stopping based on remaining time
- More logging
- Use dedicated logger for job control
- Fix: Properly set dispatcher ID
- Fix wait logic
- Switch to a much simpler way of getting remaining time
- Fix parsing of time
